### PR TITLE
Add expo build script

### DIFF
--- a/DarkChessWebApp/package.json
+++ b/DarkChessWebApp/package.json
@@ -8,6 +8,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
+    "build": "expo export:web",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add expo export script so web builds can be created with `yarn build`

## Testing
- `yarn install --frozen-lockfile`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6840795b543c832c9dd44a26f78ca6c0